### PR TITLE
Add save and load memory, and improve OpenAI compatiblity

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,33 +10,65 @@ I needed something small, clear and basic that would let me clarify my own ideas
 
 ## What's New
 
+- 31-May-2024: Bump version number for packaging to 0.0.2
+- 31-May-2024: Fixes for connecting to the actual OpenAI endpoint, rather than only local servers speaking the same protocol.
+- 21-May-2024: Added JSON encoders and decoder for saving and loading history lists from JSON files to `llmpu.history`, and `save_mem` and `load_mem` methods to the `LlmProcessingUnit` class.
 - 16-May-2024: Everything.
 
 ## Installation
 
-It's just this git repo for now, no [pypi](https://pypi.org/) package yet. So clone the repo or add it as a submodule to your project and `pip install -r` the `requirements.txt` into your python [virtual environment](https://docs.python.org/3/library/venv.html). You did make one, right?
+It's just this git repo for now, not up on [pypi](https://pypi.org/) as a full release yet. So add the an entry in your `requirements.txt` pointing to this repo, such as:
+
+```
+llm-processing-unit @ git+https://github.com/one-lithe-rune/llm-processing-unit.git
+```
+
+...and `pip install -r` the `requirements.txt` into your python [virtual environment](https://docs.python.org/3/library/venv.html). You did make one, right?
 
 ## Usage Example
 
 ```Python
 
 # You're obviously going to need a connection to an LLM of some kind.
-# This example is for a local server running on port 5001 that can
-# speak the OpenAI Chat protocol using REST. This is the only server
-# protocol I've implemented so far.
+# This example is connecting to a server that can speak the OpenAI
+# Chat protocol using REST. This is the only server protocol I've
+# implemented so far.
 
 # The LLM you're using will want things in some particular format,
 # I've implemented Alpaca, Llama 3 Chat, Llama 3 Character Chat,
 # Llama 3 base and Open AI Chat. Only the first three are much tested.
 
-from llmpu.formatters import Llama3InstructSessionFormatter
 from llmpu.sessions import OAICompatibleChatSession
 
-endpoint = OAICompatibleChatSession(
-    host="http://localhost:5001/",
-    initial_processors=[Llama3InstructSessionFormatter],
-    extra_props={ "temperature": 0.7 },
-)
+ai_server_type = "local"
+
+if ai_server_type = "local":
+    # Connecting to a local server that exposes an endpoint compatible
+    # with OpenAI, such as llama-cpp-python, koboldcpp or others, running
+    # a model that expects the Llama 3 instruct format
+    from llmpu.formatters import Llama3InstructSessionFormatter
+
+    endpoint = OAICompatibleChatSession(
+        host="http://localhost:5001/",
+        initial_processors=[Llama3InstructSessionFormatter],
+        extra_props={ "temperature": 0.7 },
+    )
+else:
+    import os
+    from llmpu.formatters import OAIChatSessionFormatter
+
+    # Connecting to the actual OpenAI server endpoint reading
+    # API key etc. from environment variables
+    endpoint = OAICompatibleChatSession(
+        host="https://api.openai.com/",
+        initial_processors=[OAIChatSessionFormatter],
+        host="http://localhost:5001/",
+        model="gpt4o",
+        extra_props={ "temperature": 0.7 },
+        api_key=os.environ["OPENAI_API_KEY"],
+        api_org=os.environ["OPENAI_API_ORG"] if "OPEN_AI_API_ORG" in os.environ else None,
+        api_proj=os.environ["OPENAI_API_PROJ"] if "OPEN_AI_API_PROJ" in os.environ else None,
+    )
 
 # The processing unit is implemented by the LlmProcessingUnit class
 from llmpu import LlmProcessingUnit
@@ -98,12 +130,13 @@ llm.evaluate()
 
 ## Obligatory Chatbot Example
 
-If you're cloned the repo, activated your venv and installed the requirements, you should be able to run the obligatory ChatBot example by doing `python -m llmpu.examples.chat`. See the connection options by doing `python -m llmpu.examples.chat --help`
+If you've cloned the repo, activated your venv and installed the requirements, you should be able to run the obligatory ChatBot example by doing `python -m llmpu.examples.chat`. See the connection options by doing `python -m llmpu.examples.chat --help`
 
 ## What's 'Supported'
 
 - Python 3.11
-- As much of the OpenAI chat endpoint protocol sufficient to work against a compatible local AI server endpoint in non-streaming mode but not necessarily enough for a real OpenAI endpoint.
-- Formatters for [Alpaca](https://github.com/tatsu-lab/stanford_alpaca?tab=readme-ov-file#data-release), [Llama 3 Chat](https://llama.meta.com/docs/model-cards-and-prompt-formats/meta-llama-3), Llama 3 Character Chat, [Llama 3 Base](https://llama.meta.com/docs/model-cards-and-prompt-formats/meta-llama-3) and Open AI Chat formats. Only the first three can be considered tested.
+- As much of the OpenAI chat endpoint protocol sufficient to work against a compatible local AI server endpoint in non-streaming mode, and the real OpenAI chat endpoint also in non-streaming mode.
+- Formatters for [Alpaca](https://github.com/tatsu-lab/stanford_alpaca?tab=readme-ov-file#data-release), [Llama 3 Chat](https://llama.meta.com/docs/model-cards-and-prompt-formats/meta-llama-3), Llama 3 Character Chat, [Llama 3 Base](https://llama.meta.com/docs/model-cards-and-prompt-formats/meta-llama-3) and Open AI Chat formats. Make sure you use the right (or at least sensible) formatter for the model you will be using.
 
 I've been developing this against my local instance of [koboldcpp](https://github.com/LostRuins/koboldcpp)/[koboldcpp-rocm](https://github.com/YellowRoseCx/koboldcpp-rocm/) on Linux with various GGUF quantised [Llama 3 8B](https://lama.meta.com/docs/get-started/) variants. So that *should* work.
+I've now tested against the actual OpenAI api chat endpoint, so that should also work.

--- a/llmpu/history/__init__.py
+++ b/llmpu/history/__init__.py
@@ -2,4 +2,6 @@ from .history import (
     HistoryTurn,
     HistoryJSONDecoder,
     HistoryJSONEncoder,
+    load_history,
+    save_history,
 )

--- a/llmpu/history/history.py
+++ b/llmpu/history/history.py
@@ -1,5 +1,6 @@
 import json
 
+from pathlib import Path
 from dataclasses import dataclass
 
 
@@ -27,3 +28,31 @@ class HistoryJSONDecoder(json.JSONDecoder):
         if "role" in obj and "content" in obj:
             return HistoryTurn(**obj)
         return obj
+
+
+def load_history(file_path: Path) -> list[HistoryTurn]:
+    """
+    loads data from a JSON file into the history. Answers
+    a empty list if the requested file does not exist
+    """
+    result: list[HistoryTurn] = list()
+
+    if Path(file_path).exists():
+        with open(file_path) as file:
+            result = json.load(file, cls=HistoryJSONDecoder)
+
+        print(f"loaded: {file_path}")
+    else:
+        print(f"not found: {file_path}")
+
+    return result
+
+
+def save_history(file_path, turns: list[HistoryTurn]):
+    """
+    saves the history data to a JSON file, overwriting the file
+    if it already exists.
+    """
+
+    with open(file_path, mode="w+") as file:
+        json.dump(turns, file, indent=4, cls=HistoryJSONEncoder)

--- a/llmpu/sessions/args.py
+++ b/llmpu/sessions/args.py
@@ -8,31 +8,49 @@ def add_args(
     parser: ArgumentParser,
     default_host="http://localhost:5001",
     default_type="openai_compatible",
+    default_model=None,
     default_api_key=None,
+    default_api_org=None,
+    default_api_proj=None,
 ):
     """
     Add command line arguments to an argument parser, allowing a
     session connecting to an AI server to be configured
     """
     parser.add_argument(
-        "-H",
         "--ai-host",
         default=default_host,
         help="host name or ip address of the AI server, include port if applicable",
     )
     parser.add_argument(
-        "-s",
         "--ai-session-type",
         choices=["openai_compatible"],
         default=default_type,
         help="Which session type to use use when connecting to the ai server",
     )
     parser.add_argument(
-        "-k",
+        "--ai-model",
+        type=str,
+        default=default_model,
+        help="api key for the AI server, if applicable",
+    )
+    parser.add_argument(
         "--ai-api-key",
         type=str,
         default=default_api_key,
         help="api key for the AI server, if applicable",
+    )
+    parser.add_argument(
+        "--ai-api-org",
+        type=str,
+        default=default_api_org,
+        help="organization to pass to the AI server api, if applicable",
+    )
+    parser.add_argument(
+        "--ai-api-project",
+        type=str,
+        default=default_api_proj,
+        help="project to pass to the AI server api, if applicable",
     )
 
 
@@ -43,4 +61,7 @@ def from_args(args: Namespace) -> BaseSession:
     return {"openai_compatible": OAICompatibleChatSession}[args.ai_session_type](
         host=args.ai_host,
         api_key=args.ai_api_key,
+        api_org=args.ai_api_org,
+        api_proj=args.ai_api_project,
+        model=args.ai_model,
     )

--- a/llmpu/sessions/base.py
+++ b/llmpu/sessions/base.py
@@ -9,6 +9,10 @@ from llmpu.formatters import BaseSessionFormatter
 Jsonable = dict[str, "Jsonable"] | list["Jsonable"] | str | int | float | bool | None
 
 
+class SessionError(Exception):
+    pass
+
+
 class BaseSession(ABC):
     """
     Base class for retrieving responses from AI provider endpoint

--- a/llmpu/sessions/base.py
+++ b/llmpu/sessions/base.py
@@ -21,7 +21,6 @@ class BaseSession(ABC):
         initial_processors: list[BaseSessionFormatter] = None,
         token_limit: int = 1024,
         extra_props: dict = None,
-        history: list[HistoryTurn] = None,
     ):
         self._session: requests.Session = requests.Session()
         self._endpoint = urljoin(host, path)
@@ -29,7 +28,6 @@ class BaseSession(ABC):
         self._extra_props = extra_props if extra_props is not None else dict()
         self._last_response: Jsonable = None
 
-        self.history = history if history else []
         self.processors = (
             initial_processors if initial_processors is not None else list()
         )

--- a/llmpu/sessions/oai_compatible.py
+++ b/llmpu/sessions/oai_compatible.py
@@ -17,12 +17,30 @@ class OAICompatibleChatSession(BaseSession):
         initial_processors: list[BaseSessionFormatter] = None,
         token_limit: int = 1024,
         extra_props: dict = None,
+        model: str = None,
         api_key: str = None,
+        api_org: str = None,
+        api_proj: str = None,
     ):
         super().__init__(host, path, initial_processors, token_limit, extra_props)
-        if api_key is not None:
-            self._session.headers = {"Authorization", f"Bearer {api_key}"}
+
+        self._session_headers: dict[str, str] = {}
         self._api_key: str = api_key
+        self._api_org: str = api_org
+        self._api_proj: str = api_proj
+        self._model: str = model
+
+        if api_key is not None:
+            self._session.headers["Authorization"] = f"Bearer {api_key}"
+        if api_org is not None:
+            self._session.headers["OpenAI-Organization"] = api_org
+        if api_proj is not None:
+            self._session.headers["OpenAI-Project"] = api_proj
+
+        self._session.headers = self._session_headers
+
+        if model is not None:
+            self._extra_props["model"] = model
 
     def close(self):
         self._session.close()

--- a/llmpu/sessions/oai_compatible.py
+++ b/llmpu/sessions/oai_compatible.py
@@ -1,9 +1,8 @@
 import requests
-from urllib.parse import urljoin
 
 from llmpu.formatters import BaseSessionFormatter
 from llmpu.history import HistoryTurn
-from .base import BaseSession, Jsonable
+from .base import BaseSession
 
 
 class OAICompatibleChatSession(BaseSession):
@@ -18,24 +17,12 @@ class OAICompatibleChatSession(BaseSession):
         initial_processors: list[BaseSessionFormatter] = None,
         token_limit: int = 1024,
         extra_props: dict = None,
-        history: list = None,
         api_key: str = None,
     ):
-        self._session: requests.Session = requests.Session()
+        super().__init__(host, path, initial_processors, token_limit, extra_props)
         if api_key is not None:
             self._session.headers = {"Authorization", f"Bearer {api_key}"}
-        self._endpoint: str = urljoin(host, path)
-        self._token_limit: int = token_limit
-        self._extra_props: dict[str, str] = (
-            extra_props if extra_props is not None else dict()
-        )
         self._api_key: str = api_key
-        self._last_response: Jsonable = None
-
-        self.history = history if history else []
-        self.processors = (
-            initial_processors if initial_processors is not None else list()
-        )
 
     def close(self):
         self._session.close()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "llm-processing-unit"
-version = "0.0.1"
+version = "0.0.2"
 description = "A small Python library that treats a connection to an LLM as if it were analogous to the ALU of a very simple 8-Bit style processor of yore "
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
## Motivation

I wanted this to work with an actual OpenAI endpoint, not just local LLM servers, and to be able to save and load the LlmProcessingUnit memory to a file.

## Changes

- Fix OAICompatibleChatSession calling not calling `super().__init__` or calling it incorrectly.
- Add optional `model`, `api_key`, `api_org`, and `api_proj` parameters to the OAICompatibleChatSession constructor, and send them in requests to the AI server if they have been set. You need at least `api_key` and `model` set appropriately if you are using a real true OpenAI endpoint.
- Expose equivalent command line parameters for the above in the command line parameter helpers.
- Add load_history and save_history functions to the History module, for saving and loading HistoryTurn lists.
- Add load_mem and save_mem methods to LlmProcessingUnit to save the entire processing unit memory.
- Bump package version.